### PR TITLE
Link the CSS file directly

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -27,7 +27,7 @@ add_action( 'after_setup_theme', 'flat_setup' );
 function flat_scripts_styles() {
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) )
 		wp_enqueue_script( 'comment-reply' );
-	wp_enqueue_style( 'flat-style', get_stylesheet_uri() );
+	wp_enqueue_style( 'flat-style', get_template_directory_uri() . '/assets/css/template.css' );
 	wp_enqueue_script( 'flat-bootstrap', get_template_directory_uri() . '/assets/js/bootstrap-3.1.0.min.js', array( 'jquery' ), '3.1.0', true );
     wp_enqueue_script( 'flat-functions', get_template_directory_uri() . '/assets/js/functions.js', array( 'jquery', 'flat-bootstrap' ), '20131228', true );
 }

--- a/style.css
+++ b/style.css
@@ -13,7 +13,3 @@ Tags: black, orange, white, white, dark, light, two-columns, left-sidebar, post-
 This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 */
-
-@import url('assets/css/template.css');
-.sticky {}
-.bypostauthor {}


### PR DESCRIPTION
Using @import in CSS is bad for performance, we don't have to include style.css of the theme, just including the CSS directly is fine
