### PR TITLE
Prevent error on default font selection

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -247,8 +247,11 @@ function flat_custom_font() {
       $font_style.= "#masthead .site-description, .hentry .entry-meta {font-family:".$sub_heading_font_family."}";
     }
 
-    echo str_replace('family=|', 'family=', "<link href='http://fonts.googleapis.com/css?family=".str_replace(' ', '+', $font_import)."' rel='stylesheet' type='text/css'>");
-    echo "<style type='text/css'>".$font_style."</style>";
+    if( !empty($font_import) ) {
+      echo str_replace('family=|', 'family=', "<link href='http://fonts.googleapis.com/css?family=".str_replace(' ', '+', $font_import)."' rel='stylesheet' type='text/css'>");
+      echo "<style type='text/css'>".$font_style."</style>";
+    }
+    
   }
 }
 add_action( 'wp_head', 'flat_custom_font' );


### PR DESCRIPTION
Seen in console on clean install (using default font selection):

```
GET https://fonts.googleapis.com/css?family=%27 400 (Bad Request) 
```

It is possible for $font_import to still be empty after missing each if statement.

Minor issue in a fantastic theme - thanks for all the effort put into this.
