### PR TITLE
Added six new theme customizer options

### DIFF
--- a/content.php
+++ b/content.php
@@ -8,20 +8,22 @@
 			<a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'flat' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_title(); ?></a>
 		</h2>
 		<?php endif; ?>
-		<div class="entry-meta">
-			<?php flat_entry_meta(); ?>
-		</div>
+        <?php if ( flat_show_metadata(is_single()) ) : ?>
+            <div class="entry-meta">
+                <?php flat_entry_meta(); ?>
+            </div>
+        <?php endif; ?>
 	</header>
 
 	<?php if ( has_post_thumbnail() && ! post_password_required() ) : ?>
-		<?php if ( ! is_single() && flat_get_theme_option('archive_featured_image') == 'display' ) { ?>
+		<?php if ( ! is_single() && flat_get_theme_option('archive_featured_image') == '1' ) { ?>
 			<div class="entry-thumbnail"><a href="<?php the_permalink(); ?>" title="<?php echo esc_attr( sprintf( __( 'Permalink to %s', 'flat' ), the_title_attribute( 'echo=0' ) ) ); ?>" rel="bookmark"><?php the_post_thumbnail(); ?></a></div>
-		<?php } else if ( is_single() && flat_get_theme_option('single_featured_image') == 'display' ) { ?>
+		<?php } else if ( is_single() && flat_get_theme_option('single_featured_image') == '1' ) { ?>
 			<div class="entry-thumbnail"><?php the_post_thumbnail(); ?></div>
 		<?php } ?>
   <?php endif; ?>
 
-	<?php if ( is_search() || ( !is_single() && flat_get_theme_option('archive_content') == 'excerpt' ) ) : ?>
+	<?php if ( is_search() || ( !is_single() && flat_get_theme_option('archive_content') == '0' ) ) : ?>
 	<div class="entry-summary">
 		<?php the_excerpt(); ?>
 	</div>
@@ -39,6 +41,6 @@
 	} ?>
 </article>
 
-<?php if ( is_single() && get_the_author_meta( 'description' ) ) : ?>
+<?php if ( is_single() && get_the_author_meta( 'description' ) && flat_get_theme_option('single_author_box') == '1' ) : ?>
 	<?php get_template_part( 'author-bio' ); ?>
 <?php endif; ?>

--- a/functions.php
+++ b/functions.php
@@ -70,6 +70,14 @@ function flat_entry_meta( $show_sep = true ) {
     echo '<span class="comments-link">'.comments_popup_link( __( '0 Comment', 'flat' ), __( '1 Comment', 'flat' ), __( '% Comments', 'flat' ) ) . '</span>';
 }
 
+// return whether we display post metadata on single post ($is_single = true) or archive pages ($is_single = false)
+function flat_show_metadata($is_single) {
+    if ($is_single) {
+        return flat_get_theme_option('single_metadata') == '1';
+    }
+    return flat_get_theme_option('archive_metadata') == '1';
+}
+
 function flat_paging_nav() {
 	global $wp_query, $paged;
 

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -154,55 +154,80 @@ function flat_customize_register( $wp_customize ) {
       'News Cycle' => 'News Cycle'
     ),
   ));
-	$wp_customize->add_section('layout', array(
-		'title'    => __('Layout', 'flat'),
-		'priority' => 70,
+	$wp_customize->add_section('layout_single', array(
+		'title'    => __('Single Post', 'flat'),
+		'priority' => 110,
 	));
 	$wp_customize->add_setting('flat_theme_options[single_featured_image]', array(
-		'default'        => 'hide',
+		'default'        => '1',
 		'capability'     => 'edit_theme_options',
 		'type'           => 'option',
 	));
-	$wp_customize->add_control('single_featured_image', array(
-		'settings' => 'flat_theme_options[single_featured_image]',
-		'label' => __('Featured image single page', 'flat'),
-		'section' => 'layout',
-		'type'    => 'select',
-		'choices'    => array(
-			'display' => 'Display',
-			'hide' => 'Do not display',
-		),
-	));
+    $wp_customize->add_control('single_featured_image', array(
+        'label'      => __('Show Featured Image', 'flat'),
+        'section'    => 'layout_single',
+        'settings'   => 'flat_theme_options[single_featured_image]',
+        'type'       => 'checkbox'
+    ) );
+    $wp_customize->add_setting('flat_theme_options[single_metadata]', array(
+        'default'        => '1',
+        'capability'     => 'edit_theme_options',
+        'type'           => 'option',
+    ));
+    $wp_customize->add_control('single_metadata', array(
+        'label'      => __('Show Metadata', 'flat'),
+        'section'    => 'layout_single',
+        'settings'   => 'flat_theme_options[single_metadata]',
+        'type'       => 'checkbox'
+    ) );
+    $wp_customize->add_setting('flat_theme_options[single_author_box]', array(
+        'default'        => '1',
+        'capability'     => 'edit_theme_options',
+        'type'           => 'option',
+    ));
+    $wp_customize->add_control('single_author_box', array(
+        'label'      => __('Show Author Box', 'flat'),
+        'section'    => 'layout_single',
+        'settings'   => 'flat_theme_options[single_author_box]',
+        'type'       => 'checkbox'
+    ) );
+    $wp_customize->add_section('layout_archive', array(
+        'title'    => __('Archive Pages', 'flat'),
+        'priority' => 100,
+    ));
 	$wp_customize->add_setting('flat_theme_options[archive_featured_image]', array(
-		'default'        => 'display',
+        'default'        => '',
 		'capability'     => 'edit_theme_options',
 		'type'           => 'option',
 	));
-	$wp_customize->add_control('archive_featured_image', array(
-		'settings' => 'flat_theme_options[archive_featured_image]',
-		'label' => __('Featured image archive page', 'flat'),
-		'section' => 'layout',
-		'type'    => 'select',
-		'choices'    => array(
-			'display' => 'Display',
-			'hide' => 'Do not display',
-		),
-	));
-	$wp_customize->add_setting('flat_theme_options[archive_content]', array(
-		'default'        => 'full',
-		'capability'     => 'edit_theme_options',
-		'type'           => 'option',
-	));
-	$wp_customize->add_control('archive_content', array(
-		'settings' => 'flat_theme_options[archive_content]',
-		'label' => __('Preview on archive page', 'flat'),
-		'section' => 'layout',
-		'type'    => 'select',
-		'choices'    => array(
-			'full' => 'Full content',
-			'excerpt' => 'Excerpt',
-		),
-	));
+    $wp_customize->add_control('archive_featured_image', array(
+        'label'      => __('Show Featured Image', 'flat'),
+        'section'    => 'layout_archive',
+        'settings'   => 'flat_theme_options[archive_featured_image]',
+        'type'       => 'checkbox'
+    ) );
+    $wp_customize->add_setting('flat_theme_options[archive_metadata]', array(
+        'default'        => '1',
+        'capability'     => 'edit_theme_options',
+        'type'           => 'option',
+    ));
+    $wp_customize->add_control('archive_metadata', array(
+        'label'      => __('Show Metadata', 'flat'),
+        'section'    => 'layout_archive',
+        'settings'   => 'flat_theme_options[archive_metadata]',
+        'type'       => 'checkbox'
+    ));
+    $wp_customize->add_setting('flat_theme_options[archive_content]', array(
+        'default'        => '1',
+        'capability'     => 'edit_theme_options',
+        'type'           => 'option',
+    ));
+    $wp_customize->add_control('archive_content', array(
+        'label'      => __('Show Full Content', 'flat'),
+        'section'    => 'layout_archive',
+        'settings'   => 'flat_theme_options[archive_content]',
+        'type'       => 'checkbox'
+    ));
 }
 add_action( 'customize_register', 'flat_customize_register' );
 


### PR DESCRIPTION
The following options have been added:
1. switch to enable/disable featured images on archive pages
2. switch to enable/disable featured images on single pages
3. switch between full content and excerpt on archive pages

I respected the previous behaviour in the default settings.
