### PR TITLE
Fixes extra else in content.php.

### DIFF
--- a/content.php
+++ b/content.php
@@ -19,7 +19,5 @@
     </div>
   <?php else : ?>
     <div class="entry-summary"><?php the_excerpt(); ?></div>
-  <?php else : ?>
-  
   <?php endif; ?>
 </article>


### PR DESCRIPTION
Content.php was showing this error on _3.9.0_.

``` log
Parse error: syntax error, unexpected 'else' (T_ELSE) in ../flat/content.php on line 22
```
