### PR TITLE
Partially fixes #26.

### DIFF
--- a/header.php
+++ b/header.php
@@ -19,8 +19,8 @@
 					<div class="hgroup">
 						<?php flat_logo(); ?>
 					</div>
-					<button type="button" class="btn btn-link hidden-lg toggle-sidebar" data-toggle="offcanvas"><?php _e('<i class="fa fa-gear"></i>', 'flat'); ?></button>
-					<button type="button" class="btn btn-link hidden-lg toggle-navigation"><?php _e('<i class="fa fa-bars"></i>', 'flat'); ?></button>
+					<button type="button" class="btn btn-link hidden-lg toggle-sidebar" data-toggle="offcanvas" aria-label="Sidebar"><?php _e('<i class="fa fa-gear"></i>', 'flat'); ?></button>
+					<button type="button" class="btn btn-link hidden-lg toggle-navigation" aria-label="Navigation Menu"><?php _e('<i class="fa fa-bars"></i>', 'flat'); ?></button>
 					<nav id="site-navigation" class="navigation main-navigation" role="navigation">
 						<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_class' => 'nav-menu', 'container' => false ) ); ?>
 					</nav>

--- a/languages/flat.po
+++ b/languages/flat.po
@@ -14,6 +14,14 @@ msgstr ""
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SearchPath-0: ..\n"
 
+#: ../header.php:22
+msgid "SIdebar"
+msgstr ""
+
+#: ../header.php:23
+msgid "Navigation Menu"
+msgstr ""
+
 #: ../404.php:3
 msgid "Not Found"
 msgstr ""


### PR DESCRIPTION
The "expanded" or "collapsed" state should still be provided for both buttons (using the aria-expanded attribute).
