### PR TITLE
A better "Read more" button

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -164,3 +164,10 @@ add_filter( 'wp_title', 'flat_wp_title', 10, 2 );
 
 // Add Theme Customizer functionality.
 require get_template_directory() . '/inc/customizer.php';
+
+
+//Modifying the "Read more" button.
+add_filter( 'the_content_more_link', 'modify_read_more_link' );
+function modify_read_more_link() {
+	return '<a class="btn btn-default btn-sm" href="' . get_permalink() . '">'.__( 'Continue reading', 'flat' ) .' &#62;&#62;</a>';
+}


### PR DESCRIPTION
Modified following the [Wordpress Codex](http://codex.wordpress.org/Customizing_the_Read_More#Modify_The_Read_More_Link_Text).

If you think there's a better way to put it, just tell me and we can change it.


Before:
![old](https://cloud.githubusercontent.com/assets/5847145/3868561/e364bc70-204d-11e4-8740-dcb785fa6b60.jpg)

Now:
![new](https://cloud.githubusercontent.com/assets/5847145/3868564/ef104e22-204d-11e4-8d55-1222ec21af72.jpg)
