### PR TITLE
don't apply filter 'the_content' to author description

### DIFF
--- a/author-bio.php
+++ b/author-bio.php
@@ -5,8 +5,8 @@
 	<div class="author-description">
 		<h4><?php printf( __( 'About %s', 'flat' ), get_the_author() ); ?></h4>
 		<p>
-      <?php $author_description = apply_filters( 'the_content', get_the_author_meta( 'description' ) ); ?>
-      <?php echo wp_kses( $author_description, wp_kses_allowed_html( 'pre_user_description' ) ); ?>
+			<?php $author_description = get_the_author_meta( 'description' ); ?>
+			<?php echo wp_kses( $author_description, wp_kses_allowed_html( 'pre_user_description' ) ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
 				<?php printf( __( 'View all posts by %s <span class="meta-nav">&rarr;</span>', 'flat' ), get_the_author() ); ?>
 			</a>


### PR DESCRIPTION
This filter is not applied to the biography in the default themes (at least not in twentyfifteen). Applying it leads to several plugins being displayed twice -- once below the content (as intended), once again below the biography. I observed this problem when trying to display social media buttons.