### PR TITLE
Fixes from Travis CI

### DIFF
--- a/dist/functions.php
+++ b/dist/functions.php
@@ -103,23 +103,22 @@ if ( version_compare( '4.1', $wp_version, '<=' ) ) :
 		function flat_filter_scripts( $tag, $handle, $src ) {
 			# Remove `type` attribute (unneeded in HTML5)
 			$tag = str_replace( ' type=\'text/javascript\'', '', $tag );
-	
+
 			# Apply conditionals to html5shiv for legacy IE
 			if ( 'html5shiv' === $handle ) {
 				$tag = "<!--[if lt IE 9]>\n$tag<![endif]-->\n";
 			}
-	
+
 			return $tag;
 		}
 	endif;
 	add_filter( 'script_loader_tag', 'flat_filter_scripts', 10, 3 );
-# If the `script_loader_tag` filter is unavailable...
-else :
+else : # If the `script_loader_tag` filter is unavailable...
 	/**
 	 * Adds html5shiv the "old" way (WP < 4.1)
 	 */
 	function flat_add_html5shiv() {
-		echo "<!--[if lt IE 9]>\n<script src='" . esc_url( get_template_directory_uri() ) . "/assets/js/html5shiv.min.js'></script>\n<![endif]-->";
+		echo "<!--[if lt IE 9]>\n<scr" . 'ipt src="' . esc_url( get_template_directory_uri() ) . '/assets/js/html5shiv.min.js"></scr' . "ipt>\n<![endif]-->";
 	}
 	add_action( 'wp_head', 'flat_add_html5shiv' );
 endif;

--- a/dist/header.php
+++ b/dist/header.php
@@ -6,9 +6,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<link rel="profile" href="http://gmpg.org/xfn/11" />
 	<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
-	<!--[if lt IE 9]>
-	<script src="<?php echo esc_url( get_template_directory_uri() ); ?>/assets/js/html5shiv.min.js"></script>
-	<![endif]-->
 	<?php wp_head(); ?>
 </head>
 

--- a/dist/single.php
+++ b/dist/single.php
@@ -5,11 +5,11 @@
 				get_template_part( 'content', 'single' );
 
 				the_post_navigation( array(
-					'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next', 'flat' ) . '</span> ' .
-						'<span class="screen-reader-text">' . __( 'Next post:', 'flat' ) . '</span> ' .
+					'next_text' => '<span class="meta-nav" aria-hidden="true">' . esc_html__( 'Next', 'flat' ) . '</span> ' .
+						'<span class="screen-reader-text">' . esc_html__( 'Next post:', 'flat' ) . '</span> ' .
 						'<span class="post-title">%title</span>',
-					'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous', 'flat' ) . '</span> ' .
-						'<span class="screen-reader-text">' . __( 'Previous post:', 'flat' ) . '</span> ' .
+					'prev_text' => '<span class="meta-nav" aria-hidden="true">' . esc_html__( 'Previous', 'flat' ) . '</span> ' .
+						'<span class="screen-reader-text">' . esc_html__( 'Previous post:', 'flat' ) . '</span> ' .
 						'<span class="post-title">%title</span>',
 				) );
 


### PR DESCRIPTION
The past few builds have shown a few failures in Travis CI. This
*should* fix it.

* Adds HTML sanitization to single.php
* Removes html5shiv from header.php and outputs it via the WordPress
script API
* WP 4.1 is required for html5shiv conditionals to work; fallback to
adding html5shiv via the `wp_head` hook on older versions

As a bonus, on WP 4.1 (and newer), `type=“text/javascript”` will be
removed from scripts enqueued in WordPress, which cleans up header
output as that parameter is not required in HTML5.