### PR TITLE
Fixing: "Fatal error: Call to undefined function flat_body_bottom()"

### DIFF
--- a/dist/footer.php
+++ b/dist/footer.php
@@ -18,7 +18,7 @@
 		</div>
 	</div>
 </div>
-<?php flat_body_bottom(); ?>
+<?php flat_hook_body_bottom(); ?>
 <?php wp_footer(); ?>
 </body>
 </html>


### PR DESCRIPTION
I found this error on a new wp instalation and seems just it to be fixed.