### PR TITLE
Suggested fix for 1.5.7 broke wordpress

### DIFF
--- a/dist/functions.php
+++ b/dist/functions.php
@@ -62,7 +62,7 @@ if ( ! function_exists( 'flat_setup' ) ) :
 		register_nav_menu( 'primary', __( 'Navigation Menu', 'flat' ) );
 
 		# Add filters
-		add_filter( 'comments_popup_link_attributes', function() { return ' itemprop="discussionUrl"'; } ); # schema.org property on comments links
+		add_filter( 'comments_popup_link_attributes', "return ' itemprop=\"discussionUrl\"';" ); # schema.org property on comments links
 		add_filter( 'current_theme_supports-tha_hooks', '__return_true' ); # Enables checking for THA hooks
 		add_filter( 'style_loader_tag', 'flat_filter_styles', 10, 2 ); # Filters style tags as needed
 		add_filter( 'the_content_more_link', 'modify_read_more_link' ); # Enhances appearance of "Read more..." link


### PR DESCRIPTION
As discussed in forum topic https://wordpress.org/support/topic/157-broke-wordpress?replies=19, the
update to version 1.5.7 breaks the wordpress site.

I did this quickfix to be able to use the theme locally, but other users suggested a pull request. To be honest, I am not sure this fix is the best solution because I do not know enough about the intended functionality behind the changed line and because it has been said that the current code is working perfectly in newer versions of PHP (particularly the version 5.4.23).
